### PR TITLE
Convert parachain-staking for use with cumulus and pallet-session

### DIFF
--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -16,8 +16,10 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
+sp-staking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false}
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", default-features = false }
+pallet-session = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false}
 
 [dev-dependencies]
 similar-asserts = "1.1.0"
@@ -37,6 +39,8 @@ std = [
 	"serde",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-staking/std",
+	"pallet-session/std",
 ]
 runtime-benchmarks = [ "frame-benchmarking" ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -10,13 +10,13 @@ log = "0.4"
 serde = { version = "1.0.101", optional = true }
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", optional = true, default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", optional = true, default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", default-features = false }
 
 # Nimbus
@@ -25,9 +25,9 @@ nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moo
 [dev-dependencies]
 similar-asserts = "1.1.0"
 
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 
 [features]
 default = [ "std" ]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -19,6 +19,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-staking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false}
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", default-features = false }
+pallet-authorship = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false}
 pallet-session = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false}
 
 [dev-dependencies]
@@ -40,6 +41,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-staking/std",
+	"pallet-authorship/std",
 	"pallet-session/std",
 ]
 runtime-benchmarks = [ "frame-benchmarking" ]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -19,9 +19,6 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", default-features = false }
 
-# Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
-
 [dev-dependencies]
 similar-asserts = "1.1.0"
 
@@ -35,7 +32,6 @@ std = [
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
-	"nimbus-primitives/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
 	"serde",

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -24,7 +24,6 @@ use crate::{
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::{Currency, Get, OnFinalize, OnInitialize, ReservableCurrency};
 use frame_system::RawOrigin;
-use nimbus_primitives::EventHandler;
 use sp_runtime::{Perbill, Percent};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
@@ -103,13 +102,14 @@ fn create_funded_collator<T: Config>(
 }
 
 /// Run to end block and author
-fn roll_to_and_author<T: Config>(round_delay: u32, author: T::AccountId) {
+fn roll_to_and_author<T: Config>(round_delay: u32, _author: T::AccountId) {
 	let total_rounds = round_delay + 1u32;
 	let round_length: T::BlockNumber = Pallet::<T>::round().length.into();
 	let mut now = <frame_system::Pallet<T>>::block_number() + 1u32.into();
 	let end = Pallet::<T>::round().first + (round_length * total_rounds.into());
 	while now < end {
-		Pallet::<T>::note_author(author.clone());
+		// TODO: include block authoring?
+		// Pallet::<T>::note_author(author.clone());
 		<frame_system::Pallet<T>>::on_finalize(<frame_system::Pallet<T>>::block_number());
 		<frame_system::Pallet<T>>::set_block_number(
 			<frame_system::Pallet<T>>::block_number() + 1u32.into(),
@@ -973,8 +973,9 @@ benchmarks! {
 		let end = Pallet::<T>::round().first + (round_length * reward_delay.into());
 		// SET collators as authors for blocks from now - end
 		while now < end {
-			let author = collators[counter % collators.len()].clone();
-			Pallet::<T>::note_author(author);
+			// TODO: include block authoring?
+			// let author = collators[counter % collators.len()].clone();
+			// Pallet::<T>::note_author(author);
 			<frame_system::Pallet<T>>::on_finalize(<frame_system::Pallet<T>>::block_number());
 			<frame_system::Pallet<T>>::set_block_number(
 				<frame_system::Pallet<T>>::block_number() + 1u32.into()
@@ -984,7 +985,8 @@ benchmarks! {
 			now += 1u32.into();
 			counter += 1usize;
 		}
-		Pallet::<T>::note_author(collators[counter % collators.len()].clone());
+		// TODO: include block authoring?
+		// Pallet::<T>::note_author(collators[counter % collators.len()].clone());
 		<frame_system::Pallet<T>>::on_finalize(<frame_system::Pallet<T>>::block_number());
 		<frame_system::Pallet<T>>::set_block_number(
 			<frame_system::Pallet<T>>::block_number() + 1u32.into()
@@ -992,14 +994,15 @@ benchmarks! {
 		<frame_system::Pallet<T>>::on_initialize(<frame_system::Pallet<T>>::block_number());
 	}: { Pallet::<T>::on_initialize(<frame_system::Pallet<T>>::block_number()); }
 	verify {
-		// Collators have been paid
-		for (col, initial) in collator_starting_balances {
-			assert!(T::Currency::free_balance(&col) > initial);
-		}
-		// Nominators have been paid
-		for (col, initial) in delegator_starting_balances {
-			assert!(T::Currency::free_balance(&col) > initial);
-		}
+		// TODO: Verify payments once block authoring is noted
+		// // Collators have been paid
+		// for (col, initial) in collator_starting_balances {
+		//     assert!(T::Currency::free_balance(&col) > initial);
+		// }
+		// // Nominators have been paid
+		// for (col, initial) in delegator_starting_balances {
+		//     assert!(T::Currency::free_balance(&col) > initial);
+		// }
 		// Round transitions
 		assert_eq!(Pallet::<T>::round().current, before_running_round_index + reward_delay);
 	}
@@ -1104,7 +1107,8 @@ benchmarks! {
 			1u32
 		)?;
 		let start = <frame_system::Pallet<T>>::block_number();
-		Pallet::<T>::note_author(collator.clone());
+		// TODO: include block authoring?
+		// Pallet::<T>::note_author(collator.clone());
 		<frame_system::Pallet<T>>::on_finalize(start);
 		<frame_system::Pallet<T>>::set_block_number(
 			start + 1u32.into()

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -24,6 +24,7 @@ use crate::{
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::{Currency, Get, OnFinalize, OnInitialize, ReservableCurrency};
 use frame_system::RawOrigin;
+use pallet_authorship::EventHandler;
 use sp_runtime::{Perbill, Percent};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
@@ -102,14 +103,13 @@ fn create_funded_collator<T: Config>(
 }
 
 /// Run to end block and author
-fn roll_to_and_author<T: Config>(round_delay: u32, _author: T::AccountId) {
+fn roll_to_and_author<T: Config>(round_delay: u32, author: T::AccountId) {
 	let total_rounds = round_delay + 1u32;
 	let round_length: T::BlockNumber = Pallet::<T>::round().length.into();
 	let mut now = <frame_system::Pallet<T>>::block_number() + 1u32.into();
 	let end = Pallet::<T>::round().first + (round_length * total_rounds.into());
 	while now < end {
-		// TODO: include block authoring?
-		// Pallet::<T>::note_author(author.clone());
+		Pallet::<T>::note_author(author.clone());
 		<frame_system::Pallet<T>>::on_finalize(<frame_system::Pallet<T>>::block_number());
 		<frame_system::Pallet<T>>::set_block_number(
 			<frame_system::Pallet<T>>::block_number() + 1u32.into(),
@@ -973,9 +973,8 @@ benchmarks! {
 		let end = Pallet::<T>::round().first + (round_length * reward_delay.into());
 		// SET collators as authors for blocks from now - end
 		while now < end {
-			// TODO: include block authoring?
-			// let author = collators[counter % collators.len()].clone();
-			// Pallet::<T>::note_author(author);
+			let author = collators[counter % collators.len()].clone();
+			Pallet::<T>::note_author(author);
 			<frame_system::Pallet<T>>::on_finalize(<frame_system::Pallet<T>>::block_number());
 			<frame_system::Pallet<T>>::set_block_number(
 				<frame_system::Pallet<T>>::block_number() + 1u32.into()
@@ -985,8 +984,7 @@ benchmarks! {
 			now += 1u32.into();
 			counter += 1usize;
 		}
-		// TODO: include block authoring?
-		// Pallet::<T>::note_author(collators[counter % collators.len()].clone());
+		Pallet::<T>::note_author(collators[counter % collators.len()].clone());
 		<frame_system::Pallet<T>>::on_finalize(<frame_system::Pallet<T>>::block_number());
 		<frame_system::Pallet<T>>::set_block_number(
 			<frame_system::Pallet<T>>::block_number() + 1u32.into()
@@ -994,15 +992,14 @@ benchmarks! {
 		<frame_system::Pallet<T>>::on_initialize(<frame_system::Pallet<T>>::block_number());
 	}: { Pallet::<T>::on_initialize(<frame_system::Pallet<T>>::block_number()); }
 	verify {
-		// TODO: Verify payments once block authoring is noted
-		// // Collators have been paid
-		// for (col, initial) in collator_starting_balances {
-		//     assert!(T::Currency::free_balance(&col) > initial);
-		// }
-		// // Nominators have been paid
-		// for (col, initial) in delegator_starting_balances {
-		//     assert!(T::Currency::free_balance(&col) > initial);
-		// }
+		// Collators have been paid
+		for (col, initial) in collator_starting_balances {
+			assert!(T::Currency::free_balance(&col) > initial);
+		}
+		// Nominators have been paid
+		for (col, initial) in delegator_starting_balances {
+			assert!(T::Currency::free_balance(&col) > initial);
+		}
 		// Round transitions
 		assert_eq!(Pallet::<T>::round().current, before_running_round_index + reward_delay);
 	}
@@ -1107,8 +1104,7 @@ benchmarks! {
 			1u32
 		)?;
 		let start = <frame_system::Pallet<T>>::block_number();
-		// TODO: include block authoring?
-		// Pallet::<T>::note_author(collator.clone());
+		Pallet::<T>::note_author(collator.clone());
 		<frame_system::Pallet<T>>::on_finalize(start);
 		<frame_system::Pallet<T>>::set_block_number(
 			start + 1u32.into()

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1658,6 +1658,19 @@ pub mod pallet {
 		}
 	}
 
+	impl<T: Config> pallet_authorship::EventHandler<T::AccountId, T::BlockNumber> for Pallet<T> {
+		// Add reward points to block authors:
+		// * 20 points to the block producer for producing a block in the chain
+		fn note_author(author: T::AccountId) {
+			let now = <Round<T>>::get().current;
+			let score_plus_20 = <AwardedPts<T>>::get(now, &author).saturating_add(20);
+			<AwardedPts<T>>::insert(now, author, score_plus_20);
+			<Points<T>>::mutate(now, |x| *x = x.saturating_add(20));
+		}
+
+		fn note_uncle(_author: T::AccountId, _age: T::BlockNumber) {}
+	}
+
 	impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
 		fn new_session(new_index: sp_staking::SessionIndex) -> Option<Vec<T::AccountId>> {
 			log::debug!(

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1682,7 +1682,10 @@ pub mod pallet {
 			let collators = Pallet::<T>::selected_candidates().to_vec();
 			if collators.is_empty() {
 				// We never want to pass an empty set of collators. This would brick the chain.
-				log::error!("💥 keeping old session because of empty collator set!");
+				// Sessions 0, 1 are configured on genesis and use SessionConfig keys
+				if new_index > 1 {
+					log::error!("💥 keeping old session because of empty collator set!");
+				}
 				None
 			} else {
 				Some(collators)

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1657,4 +1657,27 @@ pub mod pallet {
 			Self::selected_candidates()
 		}
 	}
+
+	impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
+		fn new_session(new_index: sp_staking::SessionIndex) -> Option<Vec<T::AccountId>> {
+			log::debug!(
+				"assembling new collators for new session {} at #{:?}",
+				new_index,
+				<frame_system::Pallet<T>>::block_number(),
+			);
+
+			let collators = Pallet::<T>::selected_candidates().to_vec();
+			if collators.is_empty() {
+				// We never want to pass an empty set of collators. This would brick the chain.
+				log::error!("💥 keeping old session because of empty collator set!");
+				None
+			} else {
+				Some(collators)
+			}
+		}
+
+		fn end_session(_end_index: sp_staking::SessionIndex) {}
+
+		fn start_session(_start_index: sp_staking::SessionIndex) {}
+	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1680,4 +1680,11 @@ pub mod pallet {
 
 		fn start_session(_start_index: sp_staking::SessionIndex) {}
 	}
+
+	impl<T: Config> pallet_session::ShouldEndSession<T::BlockNumber> for Pallet<T> {
+		fn should_end_session(now: T::BlockNumber) -> bool {
+			let round = <Round<T>>::get();
+			return round.should_update(now);
+		}
+	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1652,23 +1652,6 @@ pub mod pallet {
 		}
 	}
 
-	/// Add reward points to block authors:
-	/// * 20 points to the block producer for producing a block in the chain
-	impl<T: Config> nimbus_primitives::EventHandler<T::AccountId> for Pallet<T> {
-		fn note_author(author: T::AccountId) {
-			let now = <Round<T>>::get().current;
-			let score_plus_20 = <AwardedPts<T>>::get(now, &author).saturating_add(20);
-			<AwardedPts<T>>::insert(now, author, score_plus_20);
-			<Points<T>>::mutate(now, |x| *x = x.saturating_add(20));
-		}
-	}
-
-	impl<T: Config> nimbus_primitives::CanAuthor<T::AccountId> for Pallet<T> {
-		fn can_author(account: &T::AccountId, _slot: &u32) -> bool {
-			Self::is_selected_candidate(account)
-		}
-	}
-
 	impl<T: Config> Get<Vec<T::AccountId>> for Pallet<T> {
 		fn get() -> Vec<T::AccountId> {
 			Self::selected_candidates()


### PR DESCRIPTION
This PR:
1. Converts parachain-staking to use default polkadot branches for substrate pallets
2. Implements the required traits for use with the session pallet and cumulus concensus

Reference implementations:
- https://github.com/bifrost-finance/parachain-staking
- https://github.com/KILTprotocol/mashnet-node/tree/develop/pallets/parachain-staking