### PR TITLE
Add runtime migration for initializing parachain-staking

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1735,4 +1735,29 @@ pub mod pallet {
 			)
 		}
 	}
+
+	pub struct InitGenesisOnRuntimeUpgrade<T>(PhantomData<T>);
+	impl<T: Config> frame_support::traits::OnRuntimeUpgrade for InitGenesisOnRuntimeUpgrade<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			log::info!(target: "InitGenesisOnRuntimeUpgrade", "Initializing parachain-staking");
+
+			// Set collator commission to default config
+			<CollatorCommission<T>>::put(T::DefaultCollatorCommission::get());
+			// Set parachain bond config to default config
+			<ParachainBondInfo<T>>::put(ParachainBondConfig {
+				// must be set soon; if not => due inflation will be sent to collators/delegators
+				account: T::AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
+					.expect("infinite length input; no invalid inputs for type; qed"),
+				percent: T::DefaultParachainBondReservePercent::get(),
+			});
+			// Set total selected candidates to minimum config
+			<TotalSelected<T>>::put(T::MinSelectedCandidates::get());
+			// Start Round 1
+			let round: RoundInfo<T::BlockNumber> =
+				RoundInfo::new(1u32, 0u32.into(), T::DefaultBlocksPerRound::get());
+			<Round<T>>::put(round);
+
+			T::DbWeight::get().writes(4)
+		}
+	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -420,6 +420,28 @@ pub mod pallet {
 
 			weight
 		}
+
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(target: "parachain-staking", "Initializing parachain-staking storage with config defaults");
+
+			// Set collator commission to default config
+			<CollatorCommission<T>>::put(T::DefaultCollatorCommission::get());
+			// Set parachain bond config to default config
+			<ParachainBondInfo<T>>::put(ParachainBondConfig {
+				// must be set soon; if not => due inflation will be sent to collators/delegators
+				account: T::AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
+					.expect("infinite length input; no invalid inputs for type; qed"),
+				percent: T::DefaultParachainBondReservePercent::get(),
+			});
+			// Set total selected candidates to minimum config
+			<TotalSelected<T>>::put(T::MinSelectedCandidates::get());
+			// Start Round 1
+			let round: RoundInfo<T::BlockNumber> =
+				RoundInfo::new(1u32, 0u32.into(), T::DefaultBlocksPerRound::get());
+			<Round<T>>::put(round);
+
+			T::DbWeight::get().writes(4)
+		}
 	}
 
 	#[pallet::storage]
@@ -1733,31 +1755,6 @@ pub mod pallet {
 				// One read for the round info, blocknumber is read free
 				T::DbWeight::get().reads(1),
 			)
-		}
-	}
-
-	pub struct InitGenesisOnRuntimeUpgrade<T>(PhantomData<T>);
-	impl<T: Config> frame_support::traits::OnRuntimeUpgrade for InitGenesisOnRuntimeUpgrade<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
-			log::info!(target: "InitGenesisOnRuntimeUpgrade", "Initializing parachain-staking");
-
-			// Set collator commission to default config
-			<CollatorCommission<T>>::put(T::DefaultCollatorCommission::get());
-			// Set parachain bond config to default config
-			<ParachainBondInfo<T>>::put(ParachainBondConfig {
-				// must be set soon; if not => due inflation will be sent to collators/delegators
-				account: T::AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
-					.expect("infinite length input; no invalid inputs for type; qed"),
-				percent: T::DefaultParachainBondReservePercent::get(),
-			});
-			// Set total selected candidates to minimum config
-			<TotalSelected<T>>::put(T::MinSelectedCandidates::get());
-			// Start Round 1
-			let round: RoundInfo<T::BlockNumber> =
-				RoundInfo::new(1u32, 0u32.into(), T::DefaultBlocksPerRound::get());
-			<Round<T>>::put(round);
-
-			T::DbWeight::get().writes(4)
 		}
 	}
 }


### PR DESCRIPTION
Inits select storage items in the same way that they would have been initialized if this pallet had been present at genesis.