### PR TITLE
Ensure collators are registered before joining the candidate pool

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -80,7 +80,9 @@ pub mod pallet {
 	};
 	use crate::{set::OrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo};
 	use frame_support::pallet_prelude::*;
-	use frame_support::traits::{Currency, Get, Imbalance, ReservableCurrency};
+	use frame_support::traits::{
+		Currency, Get, Imbalance, ReservableCurrency, ValidatorRegistration,
+	};
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::Decode;
 	use sp_runtime::{
@@ -168,6 +170,8 @@ pub mod pallet {
 		/// Handler to notify the runtime when a new round begin.
 		/// If you don't need it, you can specify the type `()`.
 		type OnNewRound: OnNewRound;
+		/// Whether a given collator has completed required registration to be selected as block author
+		type CollatorRegistration: ValidatorRegistration<Self::AccountId>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -215,6 +219,7 @@ pub mod pallet {
 		PendingDelegationRequestAlreadyExists,
 		PendingDelegationRequestNotDueYet,
 		CannotDelegateLessThanOrEqualToLowestBottomWhenFull,
+		CollatorNotRegistered,
 	}
 
 	#[pallet::event]
@@ -903,6 +908,10 @@ pub mod pallet {
 			let acc = ensure_signed(origin)?;
 			ensure!(!Self::is_candidate(&acc), Error::<T>::CandidateExists);
 			ensure!(!Self::is_delegator(&acc), Error::<T>::DelegatorExists);
+			ensure!(
+				T::CollatorRegistration::is_registered(&acc),
+				Error::<T>::CollatorNotRegistered
+			);
 			ensure!(
 				bond >= T::MinCandidateStk::get(),
 				Error::<T>::CandidateBondBelowMin

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -140,7 +140,17 @@ impl Config for Test {
 	type MinDelegation = MinDelegation;
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
+	type CollatorRegistration = ValidatorRegistrationMock<Self>;
 	type WeightInfo = ();
+}
+
+pub struct ValidatorRegistrationMock<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> frame_support::traits::ValidatorRegistration<T::AccountId>
+	for ValidatorRegistrationMock<T>
+{
+	fn is_registered(_id: &T::AccountId) -> bool {
+		true
+	}
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -144,12 +144,14 @@ impl Config for Test {
 	type WeightInfo = ();
 }
 
+pub const UNREGISTERED_ACCOUNT: AccountId = 99999;
 pub struct ValidatorRegistrationMock<T>(sp_std::marker::PhantomData<T>);
 impl<T: Config> frame_support::traits::ValidatorRegistration<T::AccountId>
 	for ValidatorRegistrationMock<T>
 {
-	fn is_registered(_id: &T::AccountId) -> bool {
-		true
+	fn is_registered(id: &T::AccountId) -> bool {
+		let acc: AccountId = id.to_string().parse().unwrap();
+		acc != UNREGISTERED_ACCOUNT
 	}
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -750,6 +750,25 @@ fn cannot_join_candidates_if_delegator() {
 }
 
 #[test]
+fn cannot_join_candidates_if_unregistered() {
+	use crate::mock::UNREGISTERED_ACCOUNT;
+	ExtBuilder::default()
+		.with_balances(vec![(UNREGISTERED_ACCOUNT, 1000)])
+		.with_candidates(vec![(UNREGISTERED_ACCOUNT, 500)])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				ParachainStaking::join_candidates(
+					Origin::signed(UNREGISTERED_ACCOUNT),
+					11u128,
+					100u32
+				),
+				Error::<Test>::CollatorNotRegistered
+			);
+		});
+}
+
+#[test]
 fn cannot_join_candidates_without_min_bond() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 1000)])

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -184,6 +184,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add((73_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+			// Storage: Session NextKeys (r:1 w:0) -- ValidatorRegistration
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
 	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)


### PR DESCRIPTION
In order to use parachain-staking with cumulus concensus selected collators are passed to the session pallet. Parachain-staking should avoid selecting unregistered collators for the active set. Rather than checking for compliance each time before assembling the active set, let's prevent unregistered collators from entering the candidate pool.