### PR TITLE
Remove split delegator state migration

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -443,11 +443,6 @@ pub mod pallet {
 
 			weight
 		}
-
-		fn on_runtime_upgrade() -> Weight {
-			use frame_support::traits::OnRuntimeUpgrade;
-			crate::migrations::SplitDelegatorStateIntoDelegationScheduledRequests::<T>::on_runtime_upgrade()
-		}
 	}
 
 	#[pallet::storage]


### PR DESCRIPTION
This migration was run as part of the 281 runtime upgrade.