### PR TITLE
Add AdditionalIssuance config for inflation calcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8023,8 +8023,9 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
+ "pallet-authorship",
  "pallet-balances",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -8032,6 +8033,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-staking",
  "sp-std",
  "substrate-fixed",
 ]

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -22,6 +22,7 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
+use sp_runtime::traits::Saturating;
 use sp_runtime::PerThing;
 use sp_runtime::{Perbill, RuntimeDebug};
 use substrate_fixed::transcendental::pow as floatpow;
@@ -92,7 +93,8 @@ pub fn annual_to_round<T: Config>(annual: Range<Perbill>) -> Range<Perbill> {
 
 /// Compute round issuance range from round inflation range and current total issuance
 pub fn round_issuance_range<T: Config>(round: Range<Perbill>) -> Range<BalanceOf<T>> {
-	let circulating = T::Currency::total_issuance() + T::AdditionalIssuance::additional_issuance();
+	let circulating =
+		T::Currency::total_issuance().saturating_add(T::AdditionalIssuance::additional_issuance());
 	Range {
 		min: round.min * circulating,
 		ideal: round.ideal * circulating,

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -16,6 +16,7 @@
 
 //! Helper methods for computing issuance based on inflation
 use crate::pallet::{BalanceOf, Config, Pallet};
+use crate::traits::UnvestedIssuance;
 use frame_support::traits::Currency;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -91,7 +92,7 @@ pub fn annual_to_round<T: Config>(annual: Range<Perbill>) -> Range<Perbill> {
 
 /// Compute round issuance range from round inflation range and current total issuance
 pub fn round_issuance_range<T: Config>(round: Range<Perbill>) -> Range<BalanceOf<T>> {
-	let circulating = T::Currency::total_issuance();
+	let circulating = T::Currency::total_issuance() + T::Vesting::total_unvested_issuance();
 	Range {
 		min: round.min * circulating,
 		ideal: round.ideal * circulating,

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -16,7 +16,7 @@
 
 //! Helper methods for computing issuance based on inflation
 use crate::pallet::{BalanceOf, Config, Pallet};
-use crate::traits::UnvestedIssuance;
+use crate::traits::AdditionalIssuance;
 use frame_support::traits::Currency;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -92,7 +92,7 @@ pub fn annual_to_round<T: Config>(annual: Range<Perbill>) -> Range<Perbill> {
 
 /// Compute round issuance range from round inflation range and current total issuance
 pub fn round_issuance_range<T: Config>(round: Range<Perbill>) -> Range<BalanceOf<T>> {
-	let circulating = T::Currency::total_issuance() + T::Vesting::total_unvested_issuance();
+	let circulating = T::Currency::total_issuance() + T::AdditionalIssuance::additional_issuance();
 	Range {
 		min: round.min * circulating,
 		ideal: round.ideal * circulating,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -172,6 +172,8 @@ pub mod pallet {
 		type OnNewRound: OnNewRound;
 		/// Whether a given collator has completed required registration to be selected as block author
 		type CollatorRegistration: ValidatorRegistration<Self::AccountId>;
+		/// Any unvested funds that should be used for inflation calcs
+		type Vesting: UnvestedIssuance<BalanceOf<Self>>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -172,8 +172,9 @@ pub mod pallet {
 		type OnNewRound: OnNewRound;
 		/// Whether a given collator has completed required registration to be selected as block author
 		type CollatorRegistration: ValidatorRegistration<Self::AccountId>;
-		/// Any unvested funds that should be used for inflation calcs
-		type Vesting: UnvestedIssuance<BalanceOf<Self>>;
+		/// Any additional issuance that should be used for inflation calcs
+		/// If you don't need it, you can specify the type `()`.
+		type AdditionalIssuance: AdditionalIssuance<BalanceOf<Self>>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -141,6 +141,7 @@ impl Config for Test {
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
 	type CollatorRegistration = ValidatorRegistrationMock<Self>;
+	type AdditionalIssuance = ();
 	type WeightInfo = ();
 }
 

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -43,11 +43,11 @@ impl OnNewRound for () {
 }
 
 use sp_runtime::traits::Zero;
-pub trait UnvestedIssuance<Balance> {
-	fn total_unvested_issuance() -> Balance;
+pub trait AdditionalIssuance<Balance> {
+	fn additional_issuance() -> Balance;
 }
-impl<Balance: Zero> UnvestedIssuance<Balance> for () {
-	fn total_unvested_issuance() -> Balance {
+impl<Balance: Zero> AdditionalIssuance<Balance> for () {
+	fn additional_issuance() -> Balance {
 		Zero::zero()
 	}
 }

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -41,3 +41,13 @@ impl OnNewRound for () {
 		0
 	}
 }
+
+use sp_runtime::traits::Zero;
+pub trait UnvestedIssuance<Balance> {
+	fn total_unvested_issuance() -> Balance;
+}
+impl<Balance: Zero> UnvestedIssuance<Balance> for () {
+	fn total_unvested_issuance() -> Balance {
+		Zero::zero()
+	}
+}


### PR DESCRIPTION
Allows injecting any additional planned issuance that isn't part of the currency pallet for calculating inflation based rewards.