### PR TITLE
Revert "Ensure collators are registered before joining the candidate pool (#5)"

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -80,9 +80,7 @@ pub mod pallet {
 	};
 	use crate::{set::OrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo};
 	use frame_support::pallet_prelude::*;
-	use frame_support::traits::{
-		Currency, Get, Imbalance, ReservableCurrency, ValidatorRegistration,
-	};
+	use frame_support::traits::{Currency, Get, Imbalance, ReservableCurrency};
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::Decode;
 	use sp_runtime::{
@@ -170,8 +168,6 @@ pub mod pallet {
 		/// Handler to notify the runtime when a new round begin.
 		/// If you don't need it, you can specify the type `()`.
 		type OnNewRound: OnNewRound;
-		/// Whether a given collator has completed required registration to be selected as block author
-		type CollatorRegistration: ValidatorRegistration<Self::AccountId>;
 		/// Any additional issuance that should be used for inflation calcs
 		/// If you don't need it, you can specify the type `()`.
 		type AdditionalIssuance: AdditionalIssuance<BalanceOf<Self>>;
@@ -222,7 +218,6 @@ pub mod pallet {
 		PendingDelegationRequestAlreadyExists,
 		PendingDelegationRequestNotDueYet,
 		CannotDelegateLessThanOrEqualToLowestBottomWhenFull,
-		CollatorNotRegistered,
 	}
 
 	#[pallet::event]
@@ -889,10 +884,6 @@ pub mod pallet {
 			let acc = ensure_signed(origin)?;
 			ensure!(!Self::is_candidate(&acc), Error::<T>::CandidateExists);
 			ensure!(!Self::is_delegator(&acc), Error::<T>::DelegatorExists);
-			ensure!(
-				T::CollatorRegistration::is_registered(&acc),
-				Error::<T>::CollatorNotRegistered
-			);
 			ensure!(
 				bond >= T::MinCandidateStk::get(),
 				Error::<T>::CandidateBondBelowMin

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -140,20 +140,8 @@ impl Config for Test {
 	type MinDelegation = MinDelegation;
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
-	type CollatorRegistration = ValidatorRegistrationMock<Self>;
 	type AdditionalIssuance = ();
 	type WeightInfo = ();
-}
-
-pub const UNREGISTERED_ACCOUNT: AccountId = 99999;
-pub struct ValidatorRegistrationMock<T>(sp_std::marker::PhantomData<T>);
-impl<T: Config> frame_support::traits::ValidatorRegistration<T::AccountId>
-	for ValidatorRegistrationMock<T>
-{
-	fn is_registered(id: &T::AccountId) -> bool {
-		let acc: AccountId = id.to_string().parse().unwrap();
-		acc != UNREGISTERED_ACCOUNT
-	}
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -750,25 +750,6 @@ fn cannot_join_candidates_if_delegator() {
 }
 
 #[test]
-fn cannot_join_candidates_if_unregistered() {
-	use crate::mock::UNREGISTERED_ACCOUNT;
-	ExtBuilder::default()
-		.with_balances(vec![(UNREGISTERED_ACCOUNT, 1000)])
-		.with_candidates(vec![(UNREGISTERED_ACCOUNT, 500)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				ParachainStaking::join_candidates(
-					Origin::signed(UNREGISTERED_ACCOUNT),
-					11u128,
-					100u32
-				),
-				Error::<Test>::CollatorNotRegistered
-			);
-		});
-}
-
-#[test]
 fn cannot_join_candidates_without_min_bond() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 1000)])

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -184,8 +184,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add((73_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
-			// Storage: Session NextKeys (r:1 w:0) -- ValidatorRegistration
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
 	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)


### PR DESCRIPTION
This reverts commit 9824ec8ff4e6d84c049b6bff1f8d416a0d6c6bc9.

The marginal value brought on by this change isn't worth the ongoing support burden. This change broke benchmark generation due to the addition of a new Config value. Fixing the benchmarks requires a large code change that we'll have to maintain as we pull in more upstream changes.

Our 20+ active collators also mitigate the risk of a small number of collators joining the candidate pool without active session keys. As long as the system is still producing blocks offending collators will be able to recognize that they are not producing blocks and fix the issue. The incentive on the collator's side is economic. They've bonded a significant number of tokens and need to produce blocks to make a return.