### PR TITLE
Add delegator_bond_till_min to DelegatorActions

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -79,6 +79,7 @@ pub mod pallet {
 		CancelledScheduledRequest, DelegationAction, ScheduledRequest,
 	};
 	use crate::{set::OrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo};
+	use frame_support::dispatch::DispatchErrorWithPostInfo;
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
 		tokens::WithdrawReasons, Currency, Get, Imbalance, LockIdentifier, LockableCurrency,
@@ -1836,14 +1837,15 @@ pub mod pallet {
 			delegator: &T::AccountId,
 			candidate: &T::AccountId,
 			minimum: BalanceOf<T>,
-		) -> DispatchResultWithPostInfo {
+		) -> Result<BalanceOf<T>, DispatchErrorWithPostInfo> {
 			Self::get_delegator_stakable_free_balance(delegator)
 				.checked_sub(&minimum)
 				.ok_or(Error::<T>::InsufficientBalance.into())
 				.and_then(|delegation| {
 					<Self as DelegatorActions<T::AccountId, BalanceOf<T>>>::delegator_bond_more(
 						delegator, candidate, delegation,
-					)
+					)?;
+					Ok(delegation)
 				})
 		}
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -87,7 +87,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::Decode;
 	use sp_runtime::{
-		traits::{Saturating, Zero},
+		traits::{CheckedSub, Saturating, Zero},
 		Perbill, Percent, Permill,
 	};
 	use sp_std::{collections::btree_map::BTreeMap, prelude::*};
@@ -1830,6 +1830,21 @@ pub mod pallet {
 			let mut state = <DelegatorState<T>>::get(delegator).ok_or(Error::<T>::DelegatorDNE)?;
 			state.increase_delegation::<T>(candidate.clone(), more)?;
 			Ok(().into())
+		}
+
+		fn delegator_bond_till_minimum(
+			delegator: &T::AccountId,
+			candidate: &T::AccountId,
+			minimum: BalanceOf<T>,
+		) -> DispatchResultWithPostInfo {
+			Self::get_delegator_stakable_free_balance(delegator)
+				.checked_sub(&minimum)
+				.ok_or(Error::<T>::InsufficientBalance.into())
+				.and_then(|delegation| {
+					<Self as DelegatorActions<T::AccountId, BalanceOf<T>>>::delegator_bond_more(
+						delegator, candidate, delegation,
+					)
+				})
 		}
 
 		#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -9619,7 +9619,7 @@ mod delegator_actions {
 						.total(),
 					10
 				);
-				assert_ok!(ParachainStaking::delegator_bond_till_minimum(&2, &1, 1),);
+				assert_ok!(ParachainStaking::delegator_bond_till_minimum(&2, &1, 1), 4);
 				assert_eq!(
 					ParachainStaking::delegator_state(2)
 						.expect("exists")

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -9572,6 +9572,65 @@ mod jit_migrate_reserve_to_locks_tests {
 	//     * other tests around lquidity checks (can't bond_more if not enough unlocked amount, etc)
 	//     * request cancellation
 }
+
+mod delegator_actions {
+	use super::*;
+	use crate::traits::DelegatorActions;
+
+	#[test]
+	fn delegate_till_min_fails_without_minimum_funds() {
+		ExtBuilder::default()
+			.with_balances(vec![(1, 30), (2, 15)])
+			.with_candidates(vec![(1, 30)])
+			.with_delegations(vec![(2, 1, 10)])
+			.build()
+			.execute_with(|| {
+				assert_eq!(
+					ParachainStaking::delegator_state(2)
+						.expect("exists")
+						.total(),
+					10
+				);
+				assert_noop!(
+					ParachainStaking::delegator_bond_till_minimum(&2, &1, 6),
+					Error::<Test>::InsufficientBalance
+				);
+				assert_eq!(
+					ParachainStaking::delegator_state(2)
+						.expect("exists")
+						.total(),
+					10
+				);
+				assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 5);
+			});
+	}
+
+	#[test]
+	fn delegate_till_min_succeeds_with_funds() {
+		ExtBuilder::default()
+			.with_balances(vec![(1, 30), (2, 15)])
+			.with_candidates(vec![(1, 30)])
+			.with_delegations(vec![(2, 1, 10)])
+			.build()
+			.execute_with(|| {
+				assert_eq!(
+					ParachainStaking::delegator_state(2)
+						.expect("exists")
+						.total(),
+					10
+				);
+				assert_ok!(ParachainStaking::delegator_bond_till_minimum(&2, &1, 1),);
+				assert_eq!(
+					ParachainStaking::delegator_state(2)
+						.expect("exists")
+						.total(),
+					14
+				);
+				assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 1);
+			});
+	}
+}
+
 #[allow(deprecated)]
 #[test]
 fn test_delegator_with_deprecated_status_leaving_can_schedule_leave_delegators_as_fix() {

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -42,7 +42,9 @@ impl OnNewRound for () {
 	}
 }
 
-use frame_support::pallet_prelude::DispatchResultWithPostInfo;
+use frame_support::{
+	dispatch::DispatchErrorWithPostInfo, pallet_prelude::DispatchResultWithPostInfo,
+};
 pub trait DelegatorActions<AccountId, Balance> {
 	fn delegator_bond_more(
 		delegator: &AccountId,
@@ -53,7 +55,7 @@ pub trait DelegatorActions<AccountId, Balance> {
 		delegator: &AccountId,
 		candidate: &AccountId,
 		minimum: Balance,
-	) -> DispatchResultWithPostInfo;
+	) -> Result<Balance, DispatchErrorWithPostInfo>;
 	#[cfg(feature = "runtime-benchmarks")]
 	fn setup_delegator(collator: &AccountId, delegator: &AccountId) -> DispatchResultWithPostInfo;
 }

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -49,6 +49,11 @@ pub trait DelegatorActions<AccountId, Balance> {
 		candidate: &AccountId,
 		more: Balance,
 	) -> DispatchResultWithPostInfo;
+	fn delegator_bond_till_minimum(
+		delegator: &AccountId,
+		candidate: &AccountId,
+		minimum: Balance,
+	) -> DispatchResultWithPostInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	fn setup_delegator(collator: &AccountId, delegator: &AccountId) -> DispatchResultWithPostInfo;
 }


### PR DESCRIPTION
Moves the logic for delegation up to a minimum to parachain-staking to take into account the new paradigm of locking delegated funds rather than reserving.
