### PR TITLE
Split delegator_bond_till_minimum function to get_delegator_stakable_free_balance, delegator_bond_more

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1991,20 +1991,8 @@ pub mod pallet {
 			state.increase_delegation::<T>(candidate.clone(), more)
 		}
 
-		fn delegator_bond_till_minimum(
-			delegator: &T::AccountId,
-			candidate: &T::AccountId,
-			minimum: BalanceOf<T>,
-		) -> Result<BalanceOf<T>, DispatchErrorWithPostInfo> {
+		fn get_delegator_stakable_free_balance(delegator: &T::AccountId) -> BalanceOf<T> {
 			Self::get_delegator_stakable_free_balance(delegator)
-				.checked_sub(&minimum)
-				.ok_or(Error::<T>::InsufficientBalance.into())
-				.and_then(|delegation| {
-					<Self as DelegatorActions<T::AccountId, BalanceOf<T>>>::delegator_bond_more(
-						delegator, candidate, delegation,
-					)?;
-					Ok(delegation)
-				})
 		}
 
 		#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -72,11 +72,7 @@ pub trait DelegatorActions<AccountId, Balance> {
 		candidate: &AccountId,
 		more: Balance,
 	) -> Result<bool, sp_runtime::DispatchError>;
-	fn delegator_bond_till_minimum(
-		delegator: &AccountId,
-		candidate: &AccountId,
-		minimum: Balance,
-	) -> Result<Balance, DispatchErrorWithPostInfo>;
+	fn get_delegator_stakable_free_balance(delegator: &AccountId) -> Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	fn setup_delegator(collator: &AccountId, delegator: &AccountId) -> DispatchResultWithPostInfo;
 }


### PR DESCRIPTION
The `delegator_bond_till_minimum` function is a custom function implemented in the OAK blockchain for the purpose of auto compounding.

To address the issue of failed bonding and the inability to reschedule a task when the balance is insufficient, the following changes have been made:

In the `delegator_bond_till_minimum` function, when the balance is insufficient, it throws an `InsufficientBalance` error. However, since this error is converted to a `DispatchError` upon function return, it is difficult to determine externally whether the error is `InsufficientBalance` in outer caller pallet. 

To overcome this, I have split the original `delegator_bond_till_minimum` logic into two separate functions: `get_delegator_stakable_free_balance` and `delegator_bond_more`.

The external caller is responsible for checking whether the balance is sufficient and then calling `delegator_bond_more`.

Added function:
- get_delegator_stakable_free_balance: Retrieves the stakable balance of the delegator.

Removed function:
- delegator_bond_till_minimum