### PR TITLE
Split delegator_bond_till_minimum function to get_delegator_stakable_free_balance, delegator_bond_more

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -82,7 +82,6 @@ pub mod pallet {
 	};
 	use crate::{set::OrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo};
 	use crate::{AutoCompoundConfig, AutoCompoundDelegations};
-	use frame_support::dispatch::DispatchErrorWithPostInfo;
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
 		tokens::WithdrawReasons, Currency, Get, Imbalance, LockIdentifier, LockableCurrency,
@@ -90,7 +89,7 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::{
-		traits::{CheckedSub, Saturating, Zero},
+		traits::{Saturating, Zero},
 		Perbill, Percent, Permill,
 	};
 	use sp_std::{collections::btree_map::BTreeMap, prelude::*};
@@ -1989,6 +1988,12 @@ pub mod pallet {
 			);
 			let mut state = <DelegatorState<T>>::get(delegator).ok_or(Error::<T>::DelegatorDNE)?;
 			state.increase_delegation::<T>(candidate.clone(), more)
+		}
+
+		fn is_delegation_exist(delegator: &T::AccountId, candidate: &T::AccountId) -> bool {
+			<DelegatorState<T>>::get(delegator)
+				.map(|state| state.get_bond_amount(candidate).is_some())
+				.unwrap_or(false)
 		}
 
 		fn get_delegator_stakable_free_balance(delegator: &T::AccountId) -> BalanceOf<T> {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1991,20 +1991,8 @@ pub mod pallet {
 			state.increase_delegation::<T>(candidate.clone(), more)
 		}
 
-		fn delegator_bond_till_minimum(
-			delegator: &T::AccountId,
-			candidate: &T::AccountId,
-			minimum: BalanceOf<T>,
-		) -> Result<BalanceOf<T>, DispatchErrorWithPostInfo> {
+		fn get_delegator_stakable_free_balance(delegator: &T::AccountId) -> BalanceOf<T> {
 			Self::get_delegator_stakable_free_balance(delegator)
-				.checked_sub(&minimum)
-				.ok_or(Error::<T>::InsufficientBalance.into())
-				.and_then(|delegation| {
-					<Self as DelegatorActions<T::AccountId, BalanceOf<T>>>::delegator_bond_more(
-						delegator, candidate, delegation,
-					)?;
-					Ok(delegation)
-				})
 		}
 
 		#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -72,11 +72,7 @@ pub trait DelegatorActions<AccountId, Balance> {
 		candidate: &AccountId,
 		more: Balance,
 	) -> Result<bool, sp_runtime::DispatchError>;
-	fn delegator_bond_till_minimum(
-		delegator: &AccountId,
-		candidate: &AccountId,
-		minimum: Balance,
-	) -> Result<Balance, DispatchErrorWithPostInfo>;
+	fn get_delegator_stakable_free_balance(delegator: &AccountId) -> Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	fn setup_delegator(collator: &AccountId, delegator: &AccountId) -> DispatchResultWithPostInfo;
 }

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -16,7 +16,7 @@
 
 //! traits for parachain-staking
 
-use frame_support::pallet_prelude::{DispatchResultWithPostInfo, Weight};
+use frame_support::pallet_prelude::Weight;
 
 pub trait OnCollatorPayout<AccountId, Balance> {
 	fn on_collator_payout(
@@ -65,16 +65,16 @@ impl<Runtime: crate::Config> PayoutCollatorReward<Runtime> for () {
 	}
 }
 
-use frame_support::dispatch::DispatchErrorWithPostInfo;
 pub trait DelegatorActions<AccountId, Balance> {
 	fn delegator_bond_more(
 		delegator: &AccountId,
 		candidate: &AccountId,
 		more: Balance,
 	) -> Result<bool, sp_runtime::DispatchError>;
+	fn is_delegation_exist(delegator: &AccountId, candidate: &AccountId) -> bool;
 	fn get_delegator_stakable_free_balance(delegator: &AccountId) -> Balance;
 	#[cfg(feature = "runtime-benchmarks")]
-	fn setup_delegator(collator: &AccountId, delegator: &AccountId) -> DispatchResultWithPostInfo;
+	fn setup_delegator(collator: &AccountId, delegator: &AccountId) -> frame_support::pallet_prelude::DispatchResultWithPostInfo;
 }
 
 use sp_runtime::traits::Zero;


### PR DESCRIPTION
The `delegator_bond_till_minimum` function is a custom function implemented in the OAK blockchain for the purpose of auto compounding.

To address the issue of failed bonding and the inability to reschedule a task when the balance is insufficient, the following changes have been made:

In the `delegator_bond_till_minimum` function, when the balance is insufficient, it throws an `InsufficientBalance` error. However, since this error is converted to a `DispatchError` upon function return, it is difficult to determine externally whether the error is `InsufficientBalance` in outer caller pallet. 

To overcome this, I have split the original `delegator_bond_till_minimum` logic into two separate functions: `get_delegator_stakable_free_balance` and `delegator_bond_more`.

The external caller is responsible for checking whether the balance is sufficient and then calling `delegator_bond_more`.

Additionally, an is_delegation_exist function has been added to check if the delegation exists.

Added function:
- is_delegation_exist: Check if the delegation exists.
- get_delegator_stakable_free_balance: Retrieves the stakable balance of the delegator.

Removed function:
- delegator_bond_till_minimum